### PR TITLE
feat(settings): add granular messaging app filters and update UI for settings

### DIFF
--- a/lib/features/music/data/repositories/music_repository.dart
+++ b/lib/features/music/data/repositories/music_repository.dart
@@ -27,20 +27,15 @@ class MusicRepository {
   Directory? _artworkCacheDir;
   final Ref _ref;
 
-  /// Patterns de chemins associés aux applications de messagerie.
-  static const List<String> _messagingAppPathPatterns = [
-    'whatsapp',
-    'com.whatsapp',
-    'telegram',
-    'org.telegram',
-    'signal',
-    'org.thoughtcrime.securesms',
+  // ─── Patterns par app ────────────────────────────────────────────────────────
+  static const _whatsappPatterns = ['whatsapp', 'com.whatsapp'];
+  static const _telegramPatterns = ['telegram', 'org.telegram'];
+  static const _signalPatterns = ['signal', 'org.thoughtcrime.securesms'];
+  static const _viberPatterns = ['viber', 'com.viber.voip'];
+  static const _discordPatterns = ['discord', 'com.discord'];
+  static const _otherPatterns = [
     'com.facebook.orca',
     'com.facebook.mlite',
-    'viber',
-    'com.viber.voip',
-    'discord',
-    'com.discord',
     'skype',
     'com.skype',
     'line',
@@ -52,9 +47,9 @@ class MusicRepository {
     'com.slack',
   ];
 
-  bool _isFromMessagingApp(String filePath) {
+  bool _matchesPatterns(String filePath, List<String> patterns) {
     final lower = filePath.toLowerCase();
-    return _messagingAppPathPatterns.any((pattern) => lower.contains(pattern));
+    return patterns.any((p) => lower.contains(p));
   }
 
   MusicRepository(this._ref) {
@@ -86,7 +81,7 @@ class MusicRepository {
       if (await Permission.notification.status.isDenied) {
         await Permission.notification.request();
       }
-      
+
       if (await Permission.storage.status.isDenied) {
         final storageStatus = await Permission.storage.request();
         if (!storageStatus.isGranted) {
@@ -94,13 +89,14 @@ class MusicRepository {
           return false;
         }
       }
-      
+
       return true;
     } on PlatformException catch (e) {
       AppLogger.e('Erreur lors de la demande de permissions', error: e);
       return false;
     } catch (e) {
-      AppLogger.e('Erreur inattendue lors de la demande de permissions', error: e);
+      AppLogger.e('Erreur inattendue lors de la demande de permissions',
+          error: e);
       return false;
     }
   }
@@ -162,7 +158,7 @@ class MusicRepository {
           );
         }
         final artist = artistMap[song.artistId!]!;
-        
+
         final albumIds = List<String>.from(artist.albumIds);
         if (song.albumId != null && !albumIds.contains(song.albumId!)) {
           albumIds.add(song.albumId!);
@@ -195,9 +191,19 @@ class MusicRepository {
 
       await _initArtworkCache();
 
-      final minDurationSeconds = await _ref.read(minSongDurationProvider.future);
+      final minDurationSeconds =
+          await _ref.read(minSongDurationProvider.future);
 
-      final excludeMessaging = await _ref.read(excludeMessagingAppsProvider.future);
+      // Lire les préférences de filtrage par app
+      final excludeGlobal =
+          await _ref.read(excludeMessagingAppsProvider.future);
+      final excludeWhatsApp = await _ref.read(excludeWhatsAppProvider.future);
+      final excludeTelegram = await _ref.read(excludeTelegramProvider.future);
+      final excludeSignal = await _ref.read(excludeSignalProvider.future);
+      final excludeViber = await _ref.read(excludeViberProvider.future);
+      final excludeDiscord = await _ref.read(excludeDiscordProvider.future);
+      final excludeOther =
+          await _ref.read(excludeOtherMessagingProvider.future);
 
       final deviceSongs = await _audioQuery.querySongs(
         sortType: aq.SongSortType.TITLE,
@@ -211,19 +217,42 @@ class MusicRepository {
 
       final mergedSongs = <SongModel>[];
       for (final deviceSong in deviceSongs) {
-        if (deviceSong.duration != null && deviceSong.duration! < (minDurationSeconds * 1000)) {
+        // Filtre durée minimale
+        if (deviceSong.duration != null &&
+            deviceSong.duration! < (minDurationSeconds * 1000)) {
           continue;
         }
 
-        if (excludeMessaging && _isFromMessagingApp(deviceSong.data)) {
-          AppLogger.d(
-            'Exclu (messagerie) : ${deviceSong.data}',
-          );
-          continue;
+        // Filtre messagerie granulaire
+        if (excludeGlobal) {
+          final p = deviceSong.data;
+          if (excludeWhatsApp && _matchesPatterns(p, _whatsappPatterns)) {
+            AppLogger.d('Exclu (WhatsApp) : $p');
+            continue;
+          }
+          if (excludeTelegram && _matchesPatterns(p, _telegramPatterns)) {
+            AppLogger.d('Exclu (Telegram) : $p');
+            continue;
+          }
+          if (excludeSignal && _matchesPatterns(p, _signalPatterns)) {
+            AppLogger.d('Exclu (Signal) : $p');
+            continue;
+          }
+          if (excludeViber && _matchesPatterns(p, _viberPatterns)) {
+            AppLogger.d('Exclu (Viber) : $p');
+            continue;
+          }
+          if (excludeDiscord && _matchesPatterns(p, _discordPatterns)) {
+            AppLogger.d('Exclu (Discord) : $p');
+            continue;
+          }
+          if (excludeOther && _matchesPatterns(p, _otherPatterns)) {
+            AppLogger.d('Exclu (Autre messagerie) : $p');
+            continue;
+          }
         }
 
         final cachedSong = cachedSongsMap[deviceSong.id.toString()];
-
         if (cachedSong != null) {
           mergedSongs.add(cachedSong.copyWith(
             title: deviceSong.title,
@@ -233,7 +262,6 @@ class MusicRepository {
             duration: deviceSong.duration ?? 0,
             albumArtPath: await _getAndCacheArtwork(
                 deviceSong.id, 'song_${deviceSong.id}'),
-            // Mettre à jour dateAdded si disponible
             dateAdded: deviceSong.dateAdded,
           ));
         } else {
@@ -341,11 +369,14 @@ class MusicRepository {
   /// Récupère les paroles en ligne : LRCLib (direct + search) puis Lyrics.ovh.
   /// Préfère les paroles synchronisées (LRC), sinon le texte brut.
   /// Un retry est fait en cas de connexion fermée / handshake (réseau instable).
-  Future<String?> getLyricsFromWeb(String artist, String title, {int? durationMs, String? album}) async {
-    var lyrics = await _getWithRetry(() => _getLyricsFromLrclib(artist, title, durationMs: durationMs, album: album));
+  Future<String?> getLyricsFromWeb(String artist, String title,
+      {int? durationMs, String? album}) async {
+    var lyrics = await _getWithRetry(() => _getLyricsFromLrclib(artist, title,
+        durationMs: durationMs, album: album));
     if (lyrics != null && lyrics.trim().isNotEmpty) return lyrics.trim();
 
-    lyrics = await _getWithRetry(() => _getLyricsFromLrclibSearch(artist, title));
+    lyrics =
+        await _getWithRetry(() => _getLyricsFromLrclibSearch(artist, title));
     if (lyrics != null && lyrics.trim().isNotEmpty) return lyrics.trim();
 
     lyrics = await _getWithRetry(() => _getLyricsFromLyricsOvh(artist, title));
@@ -361,17 +392,22 @@ class MusicRepository {
     return fn();
   }
 
-  Future<String?> _getLyricsFromLrclib(String artist, String title, {int? durationMs, String? album}) async {
+  Future<String?> _getLyricsFromLrclib(String artist, String title,
+      {int? durationMs, String? album}) async {
     try {
-      final durationSec = durationMs != null ? (durationMs / 1000).round() : null;
+      final durationSec =
+          durationMs != null ? (durationMs / 1000).round() : null;
       final query = <String, String>{
         'artist_name': artist,
         'track_name': title,
         if (album != null && album.isNotEmpty) 'album_name': album,
-        if (durationSec != null && durationSec > 0) 'duration': durationSec.toString(),
+        if (durationSec != null && durationSec > 0)
+          'duration': durationSec.toString(),
       };
       final uri = Uri.https('lrclib.net', 'api/get', query);
-      final response = await http.get(uri, headers: {'User-Agent': _userAgent}).timeout(_timeout, onTimeout: () => http.Response('', 408));
+      final response = await http
+          .get(uri, headers: {'User-Agent': _userAgent}).timeout(_timeout,
+              onTimeout: () => http.Response('', 408));
       if (response.statusCode != 200) return null;
       final json = jsonDecode(response.body) as Map<String, dynamic>?;
       if (json == null) return null;
@@ -386,12 +422,15 @@ class MusicRepository {
     }
   }
 
-  Future<String?> _getLyricsFromLrclibSearch(String artist, String title) async {
+  Future<String?> _getLyricsFromLrclibSearch(
+      String artist, String title) async {
     try {
       final q = '$artist $title'.trim();
       if (q.isEmpty) return null;
       final uri = Uri.https('lrclib.net', 'api/search', {'q': q, 'limit': '5'});
-      final response = await http.get(uri, headers: {'User-Agent': _userAgent}).timeout(_timeout, onTimeout: () => http.Response('', 408));
+      final response = await http
+          .get(uri, headers: {'User-Agent': _userAgent}).timeout(_timeout,
+              onTimeout: () => http.Response('', 408));
       if (response.statusCode != 200) return null;
       final list = jsonDecode(response.body) as List<dynamic>?;
       if (list == null || list.isEmpty) return null;
@@ -400,7 +439,9 @@ class MusicRepository {
       final id = first['id'];
       if (id == null) return null;
       final byIdUri = Uri.https('lrclib.net', 'api/get', {'id': id.toString()});
-      final byIdResponse = await http.get(byIdUri, headers: {'User-Agent': _userAgent}).timeout(_timeout, onTimeout: () => http.Response('', 408));
+      final byIdResponse = await http
+          .get(byIdUri, headers: {'User-Agent': _userAgent}).timeout(_timeout,
+              onTimeout: () => http.Response('', 408));
       if (byIdResponse.statusCode != 200) return null;
       final json = jsonDecode(byIdResponse.body) as Map<String, dynamic>?;
       if (json == null) return null;
@@ -410,29 +451,34 @@ class MusicRepository {
       if (plain != null && plain.trim().isNotEmpty) return plain.trim();
       return null;
     } catch (e) {
-      AppLogger.w('_getLyricsFromLrclibSearch failed for $artist / $title', error: e);
+      AppLogger.w('_getLyricsFromLrclibSearch failed for $artist / $title',
+          error: e);
       return null;
     }
   }
 
   Future<String?> _getLyricsFromLyricsOvh(String artist, String title) async {
     try {
-      final path = 'v1/${Uri.encodeComponent(artist)}/${Uri.encodeComponent(title)}';
+      final path =
+          'v1/${Uri.encodeComponent(artist)}/${Uri.encodeComponent(title)}';
       final uri = Uri.https('api.lyrics.ovh', path);
-      final response = await http.get(uri, headers: {'User-Agent': _userAgent}).timeout(_timeout, onTimeout: () => http.Response('', 408));
+      final response = await http
+          .get(uri, headers: {'User-Agent': _userAgent}).timeout(_timeout,
+              onTimeout: () => http.Response('', 408));
       if (response.statusCode != 200) return null;
       final json = jsonDecode(response.body) as Map<String, dynamic>?;
       if (json == null) return null;
       final lyrics = json['lyrics'] as String?;
       return lyrics?.trim();
     } catch (e) {
-      AppLogger.w('_getLyricsFromLyricsOvh failed for $artist / $title', error: e);
+      AppLogger.w('_getLyricsFromLyricsOvh failed for $artist / $title',
+          error: e);
       return null;
     }
   }
 
   Future<List<AlbumModel>> getAllAlbums() async {
-     return getAlbumsFromCache();
+    return getAlbumsFromCache();
   }
 
   Future<List<ArtistModel>> getAllArtists() async {

--- a/lib/features/player/presentation/providers/audio_player_provider.g.dart
+++ b/lib/features/player/presentation/providers/audio_player_provider.g.dart
@@ -24,7 +24,7 @@ final audioPlayerServiceProvider = Provider<AudioPlayerService>.internal(
 );
 
 typedef AudioPlayerServiceRef = ProviderRef<AudioPlayerService>;
-String _$audioPlayerHash() => r'a5b54a7cd0be8decf53bb279f0977ec1d654e71d';
+String _$audioPlayerHash() => r'72ce2850ab263a4a32b8849d379e7919295dcbb1';
 
 /// See also [AudioPlayer].
 @ProviderFor(AudioPlayer)

--- a/lib/features/settings/presentation/providers/settings_provider.dart
+++ b/lib/features/settings/presentation/providers/settings_provider.dart
@@ -11,7 +11,7 @@ class MinSongDuration extends _$MinSongDuration {
   @override
   Future<int> build() async {
     _prefs = await SharedPreferences.getInstance();
-    return _prefs.getInt(_key) ?? 10; // Valeur par défaut de 10 secondes
+    return _prefs.getInt(_key) ?? 10;
   }
 
   Future<void> setDuration(int seconds) async {
@@ -28,7 +28,7 @@ class OnlineFeatureEnabled extends _$OnlineFeatureEnabled {
   @override
   Future<bool> build() async {
     _prefs = await SharedPreferences.getInstance();
-    return _prefs.getBool(_key) ?? true; // Activé par défaut
+    return _prefs.getBool(_key) ?? true;
   }
 
   Future<void> setEnabled(bool enabled) async {
@@ -46,7 +46,7 @@ class ThemeModeSetting extends _$ThemeModeSetting {
   @override
   Future<int> build() async {
     _prefs = await SharedPreferences.getInstance();
-    return _prefs.getInt(_key) ?? 1; // 1 = dark par défaut
+    return _prefs.getInt(_key) ?? 1;
   }
 
   Future<void> setMode(int value) async {
@@ -55,7 +55,6 @@ class ThemeModeSetting extends _$ThemeModeSetting {
   }
 }
 
-/// Durée par défaut du minuteur de sommeil en minutes (0 = désactivé).
 @riverpod
 class SleepTimerDefaultMinutes extends _$SleepTimerDefaultMinutes {
   late SharedPreferences _prefs;
@@ -73,6 +72,9 @@ class SleepTimerDefaultMinutes extends _$SleepTimerDefaultMinutes {
   }
 }
 
+// ─── Filtres apps de messagerie
+
+/// Toggle global : active/désactive tous les filtres messagerie d'un coup.
 @riverpod
 class ExcludeMessagingApps extends _$ExcludeMessagingApps {
   late SharedPreferences _prefs;
@@ -81,7 +83,115 @@ class ExcludeMessagingApps extends _$ExcludeMessagingApps {
   @override
   Future<bool> build() async {
     _prefs = await SharedPreferences.getInstance();
-    return _prefs.getBool(_key) ?? false; // true par défaut
+    return _prefs.getBool(_key) ?? false;
+  }
+
+  Future<void> setEnabled(bool value) async {
+    state = AsyncValue.data(value);
+    await _prefs.setBool(_key, value);
+  }
+}
+
+/// WhatsApp — exclu par défaut
+@riverpod
+class ExcludeWhatsApp extends _$ExcludeWhatsApp {
+  late SharedPreferences _prefs;
+  static const _key = 'exclude_whatsapp';
+
+  @override
+  Future<bool> build() async {
+    _prefs = await SharedPreferences.getInstance();
+    return _prefs.getBool(_key) ?? true;
+  }
+
+  Future<void> setEnabled(bool value) async {
+    state = AsyncValue.data(value);
+    await _prefs.setBool(_key, value);
+  }
+}
+
+/// Telegram — inclus par défaut (bots musicaux)
+@riverpod
+class ExcludeTelegram extends _$ExcludeTelegram {
+  late SharedPreferences _prefs;
+  static const _key = 'exclude_telegram';
+
+  @override
+  Future<bool> build() async {
+    _prefs = await SharedPreferences.getInstance();
+    return _prefs.getBool(_key) ?? false;
+  }
+
+  Future<void> setEnabled(bool value) async {
+    state = AsyncValue.data(value);
+    await _prefs.setBool(_key, value);
+  }
+}
+
+/// Signal — exclu par défaut
+@riverpod
+class ExcludeSignal extends _$ExcludeSignal {
+  late SharedPreferences _prefs;
+  static const _key = 'exclude_signal';
+
+  @override
+  Future<bool> build() async {
+    _prefs = await SharedPreferences.getInstance();
+    return _prefs.getBool(_key) ?? true;
+  }
+
+  Future<void> setEnabled(bool value) async {
+    state = AsyncValue.data(value);
+    await _prefs.setBool(_key, value);
+  }
+}
+
+/// Viber — exclu par défaut
+@riverpod
+class ExcludeViber extends _$ExcludeViber {
+  late SharedPreferences _prefs;
+  static const _key = 'exclude_viber';
+
+  @override
+  Future<bool> build() async {
+    _prefs = await SharedPreferences.getInstance();
+    return _prefs.getBool(_key) ?? true;
+  }
+
+  Future<void> setEnabled(bool value) async {
+    state = AsyncValue.data(value);
+    await _prefs.setBool(_key, value);
+  }
+}
+
+/// Discord — exclu par défaut
+@riverpod
+class ExcludeDiscord extends _$ExcludeDiscord {
+  late SharedPreferences _prefs;
+  static const _key = 'exclude_discord';
+
+  @override
+  Future<bool> build() async {
+    _prefs = await SharedPreferences.getInstance();
+    return _prefs.getBool(_key) ?? true;
+  }
+
+  Future<void> setEnabled(bool value) async {
+    state = AsyncValue.data(value);
+    await _prefs.setBool(_key, value);
+  }
+}
+
+/// Autres apps (Skype, Line, WeChat, Snapchat, Slack…) — exclu par défaut
+@riverpod
+class ExcludeOtherMessaging extends _$ExcludeOtherMessaging {
+  late SharedPreferences _prefs;
+  static const _key = 'exclude_other_messaging';
+
+  @override
+  Future<bool> build() async {
+    _prefs = await SharedPreferences.getInstance();
+    return _prefs.getBool(_key) ?? true;
   }
 
   Future<void> setEnabled(bool value) async {

--- a/lib/features/settings/presentation/providers/settings_provider.g.dart
+++ b/lib/features/settings/presentation/providers/settings_provider.g.dart
@@ -60,9 +60,7 @@ typedef _$ThemeModeSetting = AutoDisposeAsyncNotifier<int>;
 String _$sleepTimerDefaultMinutesHash() =>
     r'4280b96b648ba958bf8b4540ade147dae730b7dd';
 
-/// Durée par défaut du minuteur de sommeil en minutes (0 = désactivé).
-///
-/// Copied from [SleepTimerDefaultMinutes].
+/// See also [SleepTimerDefaultMinutes].
 @ProviderFor(SleepTimerDefaultMinutes)
 final sleepTimerDefaultMinutesProvider =
     AutoDisposeAsyncNotifierProvider<SleepTimerDefaultMinutes, int>.internal(
@@ -79,7 +77,9 @@ typedef _$SleepTimerDefaultMinutes = AutoDisposeAsyncNotifier<int>;
 String _$excludeMessagingAppsHash() =>
     r'5beaccc9781cfb90edf7c1cb4f25c9d395a4291a';
 
-/// See also [ExcludeMessagingApps].
+/// Toggle global : active/désactive tous les filtres messagerie d'un coup.
+///
+/// Copied from [ExcludeMessagingApps].
 @ProviderFor(ExcludeMessagingApps)
 final excludeMessagingAppsProvider =
     AutoDisposeAsyncNotifierProvider<ExcludeMessagingApps, bool>.internal(
@@ -93,5 +93,113 @@ final excludeMessagingAppsProvider =
 );
 
 typedef _$ExcludeMessagingApps = AutoDisposeAsyncNotifier<bool>;
+String _$excludeWhatsAppHash() => r'93079ea0550bcc1f15c387cbbeac7622f591d5b4';
+
+/// WhatsApp — exclu par défaut
+///
+/// Copied from [ExcludeWhatsApp].
+@ProviderFor(ExcludeWhatsApp)
+final excludeWhatsAppProvider =
+    AutoDisposeAsyncNotifierProvider<ExcludeWhatsApp, bool>.internal(
+  ExcludeWhatsApp.new,
+  name: r'excludeWhatsAppProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$excludeWhatsAppHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ExcludeWhatsApp = AutoDisposeAsyncNotifier<bool>;
+String _$excludeTelegramHash() => r'bccfa0b1d53ffdf692f43fdc2b76aa7a290f5eb0';
+
+/// Telegram — inclus par défaut (bots musicaux)
+///
+/// Copied from [ExcludeTelegram].
+@ProviderFor(ExcludeTelegram)
+final excludeTelegramProvider =
+    AutoDisposeAsyncNotifierProvider<ExcludeTelegram, bool>.internal(
+  ExcludeTelegram.new,
+  name: r'excludeTelegramProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$excludeTelegramHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ExcludeTelegram = AutoDisposeAsyncNotifier<bool>;
+String _$excludeSignalHash() => r'2ed5ced4ed340888720efd53ae599f47d6d8436b';
+
+/// Signal — exclu par défaut
+///
+/// Copied from [ExcludeSignal].
+@ProviderFor(ExcludeSignal)
+final excludeSignalProvider =
+    AutoDisposeAsyncNotifierProvider<ExcludeSignal, bool>.internal(
+  ExcludeSignal.new,
+  name: r'excludeSignalProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$excludeSignalHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ExcludeSignal = AutoDisposeAsyncNotifier<bool>;
+String _$excludeViberHash() => r'4f44a546a54b558057a332e1c0d4d688bd39004c';
+
+/// Viber — exclu par défaut
+///
+/// Copied from [ExcludeViber].
+@ProviderFor(ExcludeViber)
+final excludeViberProvider =
+    AutoDisposeAsyncNotifierProvider<ExcludeViber, bool>.internal(
+  ExcludeViber.new,
+  name: r'excludeViberProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$excludeViberHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ExcludeViber = AutoDisposeAsyncNotifier<bool>;
+String _$excludeDiscordHash() => r'4313b8e8f66c59ecf1fe60766ebf003d541a6ac1';
+
+/// Discord — exclu par défaut
+///
+/// Copied from [ExcludeDiscord].
+@ProviderFor(ExcludeDiscord)
+final excludeDiscordProvider =
+    AutoDisposeAsyncNotifierProvider<ExcludeDiscord, bool>.internal(
+  ExcludeDiscord.new,
+  name: r'excludeDiscordProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$excludeDiscordHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ExcludeDiscord = AutoDisposeAsyncNotifier<bool>;
+String _$excludeOtherMessagingHash() =>
+    r'c472e9ced16b85382d9933b5538b7e11013e0abe';
+
+/// Autres apps (Skype, Line, WeChat, Snapchat, Slack…) — exclu par défaut
+///
+/// Copied from [ExcludeOtherMessaging].
+@ProviderFor(ExcludeOtherMessaging)
+final excludeOtherMessagingProvider =
+    AutoDisposeAsyncNotifierProvider<ExcludeOtherMessaging, bool>.internal(
+  ExcludeOtherMessaging.new,
+  name: r'excludeOtherMessagingProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$excludeOtherMessagingHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ExcludeOtherMessaging = AutoDisposeAsyncNotifier<bool>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -48,10 +48,13 @@ class SettingsScreen extends ConsumerWidget {
           isOnlineEnabled.when(
             data: (enabled) => SwitchListTile(
               title: const Text('Fonctionnalités en ligne'),
-              subtitle: const Text('Afficher le bouton pour découvrir de la musique en ligne'),
+              subtitle: const Text(
+                  'Afficher le bouton pour découvrir de la musique en ligne'),
               value: enabled,
               onChanged: (value) {
-                ref.read(onlineFeatureEnabledProvider.notifier).setEnabled(value);
+                ref
+                    .read(onlineFeatureEnabledProvider.notifier)
+                    .setEnabled(value);
               },
             ),
             loading: () => const SizedBox.shrink(),
@@ -98,7 +101,9 @@ class SettingsScreen extends ConsumerWidget {
                   divisions: 12,
                   label: '${duration.round()}s',
                   onChanged: (value) {
-                    ref.read(minSongDurationProvider.notifier).setDuration(value.round());
+                    ref
+                        .read(minSongDurationProvider.notifier)
+                        .setDuration(value.round());
                   },
                 ),
               ],
@@ -107,35 +112,121 @@ class SettingsScreen extends ConsumerWidget {
             error: (e, s) => const SizedBox.shrink(),
           ),
           const Divider(),
+          // Toggle global
           ref.watch(excludeMessagingAppsProvider).when(
-            data: (excluded) => SwitchListTile(
-              title: const Text('Exclure les apps de messagerie'),
-              subtitle: const Text(
-                'Masque les audios WhatsApp, Telegram, Signal… '
-                'lors du scan de la bibliothèque',
-              ),
-              secondary: const Icon(Icons.chat_bubble_outline),
-              value: excluded,
-              onChanged: (value) async {
-                await ref
-                    .read(excludeMessagingAppsProvider.notifier)
-                    .setEnabled(value);
-                ref.read(musicProvider.notifier).rescanLibrary();
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text(
-                      value
-                          ? 'Apps de messagerie exclues. Scan en cours…'
-                          : 'Apps de messagerie incluses. Scan en cours…',
-                    ),
-                    behavior: SnackBarBehavior.floating,
+                data: (excluded) => SwitchListTile(
+                  title: const Text('Filtrer les apps de messagerie'),
+                  subtitle: const Text(
+                    'Active le filtrage des fichiers audio provenant des apps de chat',
                   ),
-                );
-              },
-            ),
-            loading: () => const SizedBox.shrink(),
-            error: (_, __) => const SizedBox.shrink(),
-          ),
+                  secondary: const Icon(Icons.chat_bubble_outline),
+                  value: excluded,
+                  onChanged: (value) async {
+                    await ref
+                        .read(excludeMessagingAppsProvider.notifier)
+                        .setEnabled(value);
+                    ref.read(musicProvider.notifier).rescanLibrary();
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(value
+                            ? 'Filtrage activé. Scan en cours…'
+                            : 'Filtrage désactivé. Scan en cours…'),
+                        behavior: SnackBarBehavior.floating,
+                      ),
+                    );
+                  },
+                ),
+                loading: () => const SizedBox.shrink(),
+                error: (_, __) => const SizedBox.shrink(),
+              ),
+
+          // Toggles par app — visibles uniquement si le filtre global est actif
+          ref.watch(excludeMessagingAppsProvider).maybeWhen(
+                data: (excluded) => excluded
+                    ? Column(
+                        children: [
+                          const Padding(
+                            padding: EdgeInsets.fromLTRB(16, 8, 16, 4),
+                            child: Text(
+                              'Configurer par application',
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: Colors.grey,
+                              ),
+                            ),
+                          ),
+                          _buildAppToggle(
+                            context,
+                            ref,
+                            icon: Icons.message,
+                            label: 'WhatsApp',
+                            subtitle: 'Exclure les audios WhatsApp',
+                            value: ref.watch(excludeWhatsAppProvider),
+                            onChanged: (v) => ref
+                                .read(excludeWhatsAppProvider.notifier)
+                                .setEnabled(v),
+                          ),
+                          _buildAppToggle(
+                            context,
+                            ref,
+                            icon: Icons.send,
+                            label: 'Telegram',
+                            subtitle:
+                                'Exclure les audios Telegram (bots inclus)',
+                            value: ref.watch(excludeTelegramProvider),
+                            onChanged: (v) => ref
+                                .read(excludeTelegramProvider.notifier)
+                                .setEnabled(v),
+                          ),
+                          _buildAppToggle(
+                            context,
+                            ref,
+                            icon: Icons.lock_outline,
+                            label: 'Signal',
+                            subtitle: 'Exclure les audios Signal',
+                            value: ref.watch(excludeSignalProvider),
+                            onChanged: (v) => ref
+                                .read(excludeSignalProvider.notifier)
+                                .setEnabled(v),
+                          ),
+                          _buildAppToggle(
+                            context,
+                            ref,
+                            icon: Icons.phone_in_talk_outlined,
+                            label: 'Viber',
+                            subtitle: 'Exclure les audios Viber',
+                            value: ref.watch(excludeViberProvider),
+                            onChanged: (v) => ref
+                                .read(excludeViberProvider.notifier)
+                                .setEnabled(v),
+                          ),
+                          _buildAppToggle(
+                            context,
+                            ref,
+                            icon: Icons.headset_mic_outlined,
+                            label: 'Discord',
+                            subtitle: 'Exclure les audios Discord',
+                            value: ref.watch(excludeDiscordProvider),
+                            onChanged: (v) => ref
+                                .read(excludeDiscordProvider.notifier)
+                                .setEnabled(v),
+                          ),
+                          _buildAppToggle(
+                            context,
+                            ref,
+                            icon: Icons.more_horiz,
+                            label: 'Autres',
+                            subtitle: 'Skype, Line, WeChat, Snapchat, Slack…',
+                            value: ref.watch(excludeOtherMessagingProvider),
+                            onChanged: (v) => ref
+                                .read(excludeOtherMessagingProvider.notifier)
+                                .setEnabled(v),
+                          ),
+                        ],
+                      )
+                    : const SizedBox.shrink(),
+                orElse: () => const SizedBox.shrink(),
+              ),
           const Divider(),
           _buildSectionHeader(context, 'Stockage'),
           ListTile(
@@ -197,7 +288,8 @@ class SettingsScreen extends ConsumerWidget {
               value: 0,
               groupValue: current,
               onChanged: (v) {
-                if (v != null) ref.read(themeModeSettingProvider.notifier).setMode(v);
+                if (v != null)
+                  ref.read(themeModeSettingProvider.notifier).setMode(v);
                 Navigator.pop(context);
               },
             ),
@@ -206,7 +298,8 @@ class SettingsScreen extends ConsumerWidget {
               value: 1,
               groupValue: current,
               onChanged: (v) {
-                if (v != null) ref.read(themeModeSettingProvider.notifier).setMode(v);
+                if (v != null)
+                  ref.read(themeModeSettingProvider.notifier).setMode(v);
                 Navigator.pop(context);
               },
             ),
@@ -215,7 +308,8 @@ class SettingsScreen extends ConsumerWidget {
               value: 2,
               groupValue: current,
               onChanged: (v) {
-                if (v != null) ref.read(themeModeSettingProvider.notifier).setMode(v);
+                if (v != null)
+                  ref.read(themeModeSettingProvider.notifier).setMode(v);
                 Navigator.pop(context);
               },
             ),
@@ -241,7 +335,10 @@ class SettingsScreen extends ConsumerWidget {
                       value: m,
                       groupValue: current,
                       onChanged: (v) {
-                        if (v != null) ref.read(sleepTimerDefaultMinutesProvider.notifier).setDefaultMinutes(v);
+                        if (v != null)
+                          ref
+                              .read(sleepTimerDefaultMinutesProvider.notifier)
+                              .setDefaultMinutes(v);
                         Navigator.pop(context);
                       },
                     ))
@@ -262,6 +359,32 @@ class SettingsScreen extends ConsumerWidget {
               fontWeight: FontWeight.bold,
             ),
       ),
+    );
+  }
+
+  Widget _buildAppToggle(
+    BuildContext context,
+    WidgetRef ref, {
+    required IconData icon,
+    required String label,
+    required String subtitle,
+    required AsyncValue<bool> value,
+    required Future<void> Function(bool) onChanged,
+  }) {
+    return value.maybeWhen(
+      data: (excluded) => SwitchListTile(
+        dense: true,
+        contentPadding: const EdgeInsets.symmetric(horizontal: 32),
+        secondary: Icon(icon, size: 20),
+        title: Text(label),
+        subtitle: Text(subtitle, style: const TextStyle(fontSize: 11)),
+        value: excluded,
+        onChanged: (val) async {
+          await onChanged(val);
+          ref.read(musicProvider.notifier).rescanLibrary();
+        },
+      ),
+      orElse: () => const SizedBox.shrink(),
     );
   }
 }


### PR DESCRIPTION
## Type de changement

- [ ] Bugfix
- [x] Nouvelle fonctionnalité
- [ ] Documentation
- [ ] Refactor / style
- [ ] Autre (préciser)

## Description

Remplace le toggle global unique par un système de filtrage granulaire par application de messagerie. Lorsque le filtre global est activé, l'utilisateur peut choisir individuellement quelles apps exclure du scan.
Telegram est inclus par défaut pour ne pas bloquer les fichiers téléchargés via des bots musicaux. Le filtre de durée minimale existant reste complémentaire pour filtrer les courtes notes vocales.

## Checklist

- [x] Mon code suit les [CONVENTIONS](CONVENTIONS.md) du projet
- [ ] J’ai lancé `flutter analyze` sans erreur
- [x] Si j’ai modifié des modèles/providers : `dart run build_runner build` a été exécuté
- [ ] J’ai mis à jour la doc si nécessaire (README, CONVENTIONS, etc.)

## Issue liée

Clôture #2 
