### PR TITLE
chore: migrate audio plugins to audiotags and on_audio_query_pluse

### DIFF
--- a/lib/features/download/presentation/providers/download_provider.dart
+++ b/lib/features/download/presentation/providers/download_provider.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:archive/archive.dart';
-import 'package:flutter_media_metadata/flutter_media_metadata.dart';
+import 'package:audiotags/audiotags.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:musio/features/settings/presentation/providers/settings_provider.dart';
 import 'package:path/path.dart' as path;
@@ -200,19 +200,19 @@ Future<DownloadResult> downloadTrackAndAddToLibrary(
     String? albumArtPath;
 
     try {
-      final metadata = await MetadataRetriever.fromFile(file);
-      title = metadata.trackName ?? title;
-      artist = metadata.trackArtistNames?.join(', ') ?? artist;
-      album = metadata.albumName ?? album;
-      durationMs = metadata.trackDuration ?? 0;
-      year = metadata.year;
-      trackNumber = metadata.trackNumber;
-      if (metadata.albumArt != null && metadata.albumArt!.isNotEmpty) {
+      final tag = await AudioTags.read(file.path);
+      title = tag?.title ?? title;
+      artist = tag?.trackArtist ?? artist;
+      album = tag?.album ?? album;
+      durationMs = (tag?.duration ?? 0) * 1000;
+      year = tag?.year;
+      trackNumber = tag?.trackNumber;
+      if (tag?.pictures != null && tag!.pictures!.isNotEmpty) {
         final appDir = await getApplicationDocumentsDirectory();
         final artDir = Directory(path.join(appDir.path, 'album_artworks'));
         if (!await artDir.exists()) await artDir.create(recursive: true);
         final artPath = path.join(artDir.path, 'deezer_${track.id}.jpg');
-        await File(artPath).writeAsBytes(metadata.albumArt!);
+        await File(artPath).writeAsBytes(tag.pictures!.first.bytes);
         albumArtPath = artPath;
       }
     } catch (_) {
@@ -311,16 +311,16 @@ Future<DownloadResult> downloadAlbumAndAddToLibrary(
       String? albumArtPath;
 
       try {
-        final metadata = await MetadataRetriever.fromFile(outFile);
-        title = metadata.trackName ?? title;
-        artist = metadata.trackArtistNames?.join(', ') ?? artist;
-        albumName = metadata.albumName ?? albumName;
-        durationMs = metadata.trackDuration ?? 0;
-        year = metadata.year;
-        trackNumber = metadata.trackNumber;
-        if (metadata.albumArt != null && metadata.albumArt!.isNotEmpty) {
+        final tag = await AudioTags.read(outFile.path);
+        title = tag?.title ?? title;
+        artist = tag?.trackArtist ?? artist;
+        albumName = tag?.album ?? albumName;
+        durationMs = (tag?.duration ?? 0) * 1000;
+        year = tag?.year;
+        trackNumber = tag?.trackNumber;
+        if (tag?.pictures != null && tag!.pictures!.isNotEmpty) {
           final artPath = path.join(artDir.path, 'deezer_album_${album.id}_$index.jpg');
-          await File(artPath).writeAsBytes(metadata.albumArt!);
+          await File(artPath).writeAsBytes(tag.pictures!.first.bytes);
           albumArtPath = artPath;
         }
       } catch (_) {}

--- a/lib/features/music/data/repositories/music_repository.dart
+++ b/lib/features/music/data/repositories/music_repository.dart
@@ -7,7 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
 import 'package:musio/core/utils/app_logger.dart';
 import 'package:musio/features/settings/presentation/providers/settings_provider.dart';
-import 'package:on_audio_query/on_audio_query.dart' as aq;
+import 'package:on_audio_query_pluse/on_audio_query.dart' as aq;
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -336,7 +336,8 @@ class MusicRepository {
 
   /// Supprime un album de la bibliothèque (toutes les pistes) et optionnellement les fichiers.
   Future<void> removeAlbum(String albumId, {bool deleteFiles = true}) async {
-    final songs = _songBox.values.where((s) => effectiveAlbumKey(s) == albumId).toList();
+    final songs =
+        _songBox.values.where((s) => effectiveAlbumKey(s) == albumId).toList();
     for (final song in songs) {
       await _songBox.delete(song.id);
       if (deleteFiles) {
@@ -609,29 +610,25 @@ class MusicRepository {
   }
 
   Future<SongModel> _mapToSongModelWithArtwork(aq.SongModel song) async {
-    final artworkPath = await _getAndCacheArtwork(
-      song.id,
-      'song_${song.id}',
-    );
-    int? year;
-    final dynamic yearFromMap = song.getMap['year'];
-    if (yearFromMap != null) {
-      year = int.tryParse(yearFromMap.toString());
-    }
+    // Construire l'URI MediaStore directement — pas de queryArtwork
+    final albumArtUri = song.albumId != null
+        ? 'content://media/external/audio/albumart/${song.albumId}'
+        : null;
+
     return SongModel(
       id: song.id.toString(),
       title: song.title,
       artist: song.artist ?? 'Artiste inconnu',
-      album: song.album ?? 'Album inconnu',
-      path: song.data,
+      album: song.album ?? '',
+      path: song.data ?? '',
       duration: song.duration ?? 0,
-      albumArtPath: artworkPath,
+      albumArtPath: albumArtUri, // URI content:// au lieu d'un path fichier
       genre: song.genre,
-      year: year,
+      year: song.dateModified,
       trackNumber: song.track,
       albumId: song.albumId?.toString(),
       artistId: song.artistId?.toString(),
-      dateAdded: song.dateAdded, // Récupérer la date d'ajout
+      dateAdded: song.dateAdded,
     );
   }
 

--- a/lib/shared/widgets/album_art_image.dart
+++ b/lib/shared/widgets/album_art_image.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:on_audio_query/on_audio_query.dart';
+import 'package:on_audio_query_pluse/on_audio_query.dart';
 
 /// Widget réutilisable pour afficher les images d'albums
 /// Utilise le chemin du fichier en priorité, puis QueryArtworkWidget en fallback
@@ -26,7 +26,21 @@ class AlbumArtImage extends StatelessWidget {
   Widget build(BuildContext context) {
     final radius = borderRadius ?? BorderRadius.circular(8);
 
-    // Si on a un chemin et que le fichier existe, l'utiliser
+    // URI content:// MediaStore
+    if (albumArtPath != null && albumArtPath!.startsWith('content://')) {
+      return ClipRRect(
+        borderRadius: radius,
+        child: Image.network(
+          albumArtPath!,
+          width: size,
+          height: size,
+          fit: fit,
+          errorBuilder: (_, __, ___) => _buildPlaceholder(context),
+        ),
+      );
+    }
+
+    // Fichier local (téléchargements Deezer)
     if (albumArtPath != null && File(albumArtPath!).existsSync()) {
       return ClipRRect(
         borderRadius: radius,
@@ -35,15 +49,12 @@ class AlbumArtImage extends StatelessWidget {
           width: size,
           height: size,
           fit: fit,
-          errorBuilder: (context, error, stackTrace) {
-            return _buildQueryArtwork(context, radius);
-          },
+          errorBuilder: (_, __, ___) => _buildPlaceholder(context),
         ),
       );
     }
 
-    // Sinon, utiliser QueryArtworkWidget d'on_audio_query
-    return _buildQueryArtwork(context, radius);
+    return _buildPlaceholder(context);
   }
 
   Widget _buildQueryArtwork(BuildContext context, BorderRadius radius) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.25"
+  audiotags:
+    dependency: "direct main"
+    description:
+      name: audiotags
+      sha256: b09ab98c9b7d516470763d33fe974cab710bea1de24b5811339ac1b9e68268de
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.5"
   boolean_selector:
     dependency: transitive
     description:
@@ -97,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  build_cli_annotations:
+    dependency: transitive
+    description:
+      name: build_cli_annotations
+      sha256: e563c2e01de8974566a1998410d3f6f03521788160a02503b0b1f1a46c7b3d95
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   build_config:
     dependency: transitive
     description:
@@ -326,14 +342,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4+6"
-  flutter_media_metadata:
-    dependency: "direct main"
-    description:
-      name: flutter_media_metadata
-      sha256: "69cfc76ffd6cd5d546dcc4880584b3844c5e879e435aa54f57f1096c15bd04db"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0+1"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -342,6 +350,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  flutter_rust_bridge:
+    dependency: transitive
+    description:
+      name: flutter_rust_bridge
+      sha256: "35c257fc7f98e34c1314d6c145e5ed54e7c94e8a9f469947e31c9298177d546f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   flutter_shaders:
     dependency: transitive
     description:
@@ -632,22 +648,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
-  on_audio_query:
-    dependency: "direct main"
-    description:
-      name: on_audio_query
-      sha256: "28d7a247f8a0580b5d1befba15c8d8fd7e1cf3cd8e0449d54a66fc2ef27adf10"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.9.0"
-  on_audio_query_android:
-    dependency: transitive
-    description:
-      name: on_audio_query_android
-      sha256: c0b946011ee7aa8ec76b21837f0cb0007120ac291202ed6c6fb4c498ba2ff6fe
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
   on_audio_query_ios:
     dependency: transitive
     description:
@@ -664,6 +664,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.7.0"
+  on_audio_query_plus_android:
+    dependency: transitive
+    description:
+      name: on_audio_query_plus_android
+      sha256: "30ff80db9d8cbd5c3b4869bc36ff2e60ce2724d4ee19a90fa7e47ade2ab34224"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  on_audio_query_pluse:
+    dependency: "direct main"
+    description:
+      name: on_audio_query_pluse
+      sha256: d09428040e9028d1add221bfc3e53e66872c0a00117161c90f182ed6aacf731c
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
   on_audio_query_web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   # Audio
   just_audio: ^0.9.36
   audio_service: ^0.18.12
-  on_audio_query: ^2.9.0
+  on_audio_query_pluse: ^3.0.6
   rxdart: ^0.27.7
   
   # Data Models
@@ -48,7 +48,7 @@ dependencies:
   package_info_plus: ^8.0.0
   url_launcher: ^6.3.0
   # Métadonnées audio (titre, artiste, pochette, durée)
-  flutter_media_metadata: ^1.0.0
+  audiotags: ^1.4.5
   # Extraction ZIP (téléchargement d'albums)
   archive: ^4.0.2
 


### PR DESCRIPTION
## Type de changement

- [ ] Bugfix
- [ ] Nouvelle fonctionnalité
- [ ] Documentation
- [x] Refactor / style
- [ ] Autre (préciser)

## Description

Remplacement des deux packages audio abandonnés/incompatibles avec AGP 8+ par des alternatives maintenues.

- flutter_media_metadata → audiotags : lecture des métadonnées (titre, artiste, album, durée, année, numéro de piste, pochette) après téléchargement Deezer dans download_provider.dart. Correction du champ duration retourné en secondes, converti en millisecondes (* 1000).
- on_audio_query → on_audio_query_pluse : scan de la bibliothèque musicale et récupération des pochettes dans music_repository.dart. Suppression de QueryArtworkWidget dans album_art_image.dart au profit d'URIs MediaStore directes (content://media/external/audio/albumart/{albumId}) pour éviter le crash Reply already submitted du plugin.

## Checklist

- [x] Mon code suit les [CONVENTIONS](CONVENTIONS.md) du projet
- [x] J’ai lancé `flutter analyze` sans erreur
- [x] Si j’ai modifié des modèles/providers : `dart run build_runner build` a été exécuté
- [ ] J’ai mis à jour la doc si nécessaire (README, CONVENTIONS, etc.)