### PR TITLE
Ajout des autorisations pour la bibliothèque multimédia sur Android et iOS

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -5,9 +5,12 @@
 
     <!-- Permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission
             android:name="android.permission.READ_EXTERNAL_STORAGE"
             android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/apps/mobile/ios/Runner/Info.plist
+++ b/apps/mobile/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>$(PROJECT_NAME) requires access to media library</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Résumé
- Ajout des autorisations multimédia Android manquantes dans `AndroidManifest.xml` pour Android 12 et Android 13+
- Ajout de la description d'utilisation de la bibliothèque multimédia iOS (`NSAppleMusicUsageDescription`) dans `Info.plist`
- Éviter les doublons dans les entrées d'autorisation en conservant les déclarations existantes et en n'ajoutant que celles qui manquent

Closes #32 

## Plan de test
- [x] Compiler l'application Android avec succès
- [x] Compiler l'application iOS avec succès
- [x] Vérifier que la demande d'accès aux médias s'affiche lorsque cela est nécessaire sur iOS
- [x] Vérifier que les fichiers multimédias peuvent être lus sur Android 12 et Android 13+
